### PR TITLE
Expose strength in component API [closes #2, #17 and #20]

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/rnadler/ng2-password-strength-bar.svg?branch=master)](https://travis-ci.org/rnadler/ng2-password-strength-bar)
 [![npm version](https://badge.fury.io/js/ng2-password-strength-bar.svg)](https://badge.fury.io/js/ng2-password-strength-bar)
 
-This an Angular 2 implementation of [AngularJS Directive to test the strength of a password](https://blog.brunoscopelliti.com/angularjs-directive-to-test-the-strength-of-a-password/). 
+This an Angular 2 implementation of [AngularJS Directive to test the strength of a password](https://blog.brunoscopelliti.com/angularjs-directive-to-test-the-strength-of-a-password/).
 - See [Angular 2 Password Strength Bar](http://rdn-consulting.com/blog/2016/09/28/angular-2-password-strength-bar/) for details of the changes since the Angular 1 original.
 - See [Publishing an Angular 2 Component NPM Package](http://rdn-consulting.com/blog/2016/12/09/publishing-an-angular-2-component-npm-package/) for some explanation of this project.
 
@@ -88,14 +88,14 @@ export class App {
 
 - The variable containing the label displayed to the left of the bar.
 
-#### barColors (type: Array\<string\>, optional) 
+#### barColors (type: Array\<string\>, optional)
 _(New in v1.2.0)_
 - The variable can be used to define custom bar colors.<br>
 - This must be an Array of 5 strings.<br>
 - Lowest security level picks `colors[0]`, ..., the highest picks `colors[4]`.<br>
 - If not specified, the default is: `['#F00', '#F90', '#FF0', '#9F0', '#0F0']`
 
-#### baseColor (type: string, optional) 
+#### baseColor (type: string, optional)
 _(New in v1.2.1)_
 - The variable can be used to define the color of bars when no strength is applied (i.e. when there is no password text).<br>
 - If not specified, the default is: '#DDD'.<br>
@@ -104,7 +104,7 @@ For example:
 public baseColor = '#FFF';
 ```
 
-#### strengthLabels (type: Array\<string\>, optional) 
+#### strengthLabels (type: Array\<string\>, optional)
 _(New in v1.2.1)_
 - The variable can be used to define a strength label that will be appended to the colored bars.<br>
 - This must be an Array of 5 strings.<br>
@@ -112,6 +112,17 @@ For example:
 ```angular2html
 public strengthLabels = ['(Useless)', '(Weak)', '(Normal)', '(Strong)', '(Great!)'];
 ```
+
+### Output Parameters
+```angular2html
+<ng2-password-strength-bar
+  [passwordToCheck]="account.password"
+  (onStrengthChanged)="strengthChanged($event)">
+</ng2-password-strength-bar>
+```
+#### onStrengthChanged(strength: number)
+- Event triggered when the password changes.
+- Takes a single number parameter (the new password strength).
 
 ## Run the example application locally
 - `git clone https://github.com/rnadler/ng2-password-strength-bar.git`

--- a/app/app.spec.ts
+++ b/app/app.spec.ts
@@ -72,4 +72,14 @@ describe('App', function () {
       fixture.detectChanges();
       expect(bar0.nativeElement.style.backgroundColor).toBe('rgb(221, 221, 221)'); // #DDD
     });
+
+    it('should have the correct strength index on password change', () => {
+      comp.account.password = 'testinput-123';
+      fixture.detectChanges();
+      expect(comp.strength).toEqual(3);
+
+      comp.account.password = 'Testinput-123';
+      fixture.detectChanges();
+      expect(comp.strength).toEqual(4);
+    });
 });

--- a/app/app.ts
+++ b/app/app.ts
@@ -15,7 +15,8 @@ import {PasswordStrengthBarModule} from '../index';
         <ng2-password-strength-bar [passwordToCheck]="account.password" [barColors]="myColors"
                                    [barLabel]="barLabel"
                                    [baseColor]="baseColor"
-                                   [strengthLabels]="strengthLabels">
+                                   [strengthLabels]="strengthLabels"
+                                   (onStrengthChanged)="strengthChanged($event)">
         </ng2-password-strength-bar>
       </form>
     </div>
@@ -29,6 +30,11 @@ export class AppComponent {
   public barLabel = 'Password strength:';
   public strengthLabels = ['(Useless)', '(Weak)', '(Normal)', '(Strong)', '(Great!)'];
   public myColors = ['#DD2C00', '#FF6D00', '#FFD600', '#AEEA00', '#00C853'];
+  public strength = 0;
+
+  strengthChanged(strength: number) {
+    this.strength = strength;
+  }
 }
 
 @NgModule({

--- a/src/passwordStrengthBar.component.ts
+++ b/src/passwordStrengthBar.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnChanges, Input, SimpleChange} from '@angular/core';
+import {Component, OnChanges, Input, SimpleChange, Output, EventEmitter} from '@angular/core';
 
 @Component({
   selector: 'ng2-password-strength-bar',
@@ -47,6 +47,7 @@ export class PasswordStrengthBarComponent implements OnChanges {
   @Input() barColors: Array<string>;
   @Input() baseColor: string;
   @Input() strengthLabels: Array<string>;
+  @Output() onStrengthChanged: EventEmitter<number> = new EventEmitter<number>();
 
   bar0: string;
   bar1: string;
@@ -145,8 +146,10 @@ export class PasswordStrengthBarComponent implements OnChanges {
     this.setBarColors(5, this.baseColor);
     if (password) {
       const c = this.getStrengthIndexAndColor(password);
-      this.setStrengthLabel(c.idx - 1);
+      const strength = c.idx - 1;
+      this.setStrengthLabel(strength);
       this.setBarColors(c.idx, c.col);
+      this.onStrengthChanged.emit(strength);
     }
   }
 


### PR DESCRIPTION
Exposes the strength via an EventEmitter, emitting the current strength as the only single parameter, in response to changes to the password.